### PR TITLE
change CRLF to LF

### DIFF
--- a/bin/burgerjs
+++ b/bin/burgerjs
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
 require('../src/index.js');
+


### PR DESCRIPTION
Expected linebreaks to be 'LF' but found 'CRLF'. It should work only with republishing the module with LF.