### PR TITLE
Add eslint + husky

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "indent": [
+      "error",
+      4
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ]
+  }
+}

--- a/bin/burgerjs
+++ b/bin/burgerjs
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-require('../src/index.js');
-

--- a/bin/burgerjs.js
+++ b/bin/burgerjs.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../src/index.js');

--- a/package.json
+++ b/package.json
@@ -1,17 +1,36 @@
 {
   "name": "burgerjs-cli",
+  "description": "This package will install the `burgerjs` command to know when is the next BurgerJS",
   "version": "0.0.1",
   "main": "src/index.js",
   "bin": {
-    "burgerjs": "bin/burgerjs"
+    "burgerjs": "bin/burgerjs.js"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "prepush": "npm run lint"
   },
   "preferGlobal": true,
-  "repository": "git@github.com:ManRueda/burgerjs-cli.git",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/ManRueda/burgerjs-cli.git"
+  },
   "author": "Manuel Rueda <manuel.rueda.un@gmail.com>",
   "license": "MIT",
   "dependencies": {
     "got": "^6.7.1",
     "intl": "^1.2.5",
     "intl-relativeformat": "^1.3.0"
-  }
+  },
+  "devDependencies": {
+    "eslint": "^3.14.1",
+    "husky": "^0.13.1"
+  },
+  "bugs": {
+    "url": "https://github.com/ManRueda/burgerjs-cli/issues"
+  },
+  "homepage": "https://github.com/ManRueda/burgerjs-cli#readme",
+  "keywords": [
+    "hamburger"
+  ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,23 @@
-const got = require('got')
+const got = require('got');
+
 if (!global.Intl) {
-  global.Intl = require('intl')
+    global.Intl = require('intl');
 }
-const IntlRelativeFormat = require('intl-relativeformat')
-const rf = new IntlRelativeFormat('en')
+
+const IntlRelativeFormat = require('intl-relativeformat');
+const rf = new IntlRelativeFormat('en');
+
 got('https://api.meetup.com/burgerjs/events')
     .then(r => JSON.parse(r.body)[0])
     .then(r => {
-      const nextIn = rf.format(new Date(r.time + r.utc_offset))
-      console.log(`The next BurgerJS is ${nextIn}`)
-      console.log(r.link)
+        const nextIn = rf.format(new Date(r.time + r.utc_offset));
+
+        // eslint-disable-next-line no-console
+        console.log(`The next BurgerJS is ${nextIn}`);
+        // eslint-disable-next-line no-console
+        console.log(r.link);
     })
     .catch(error => {
-        console.log(error.response.body)
-    })
+        // eslint-disable-next-line no-console
+        console.error(error.response.body);
+    });


### PR DESCRIPTION
Este PR agrega una configuración básica de `eslint` y usa `husky` para que en el hook `prepush` de git corra el linter y "asegurar" que el código siga respetando el estándar establecido 👮 

![bugs-bunny-barbero](https://cloud.githubusercontent.com/assets/4248944/22533101/a7e4c6b6-e8ca-11e6-91b6-06d90568d56d.gif)
